### PR TITLE
Add access checks to dashboard and update route

### DIFF
--- a/contents/dashboardNavigation.php
+++ b/contents/dashboardNavigation.php
@@ -37,15 +37,28 @@
                     <a class="nav-item link" id="quizzes">Quizzes</a>
                     <a class="nav-item link" id="subjects">Subjects</a>
                     <a class="nav-item link" id="results">Results</a>
-                    <div class="lecturer-nav">
-                        <hr class="nav-divider">
-                        <a class="nav-item link" id="student-management">Student Management</a>
-                        <a class="nav-item link" id="test-management">Test Management</a>
-                    </div>
-                    <div class="admin-nav">
-                        <hr class="nav-divider">
-                        <a class="nav-item link" id="lecturer-management">Lecturer Management</a>
-                    </div>
+                    <?php 
+                        if (isset($_SESSION['accessLevel']) && in_array($_SESSION['accessLevel'], ["LECTURER", "ADMIN"])) {
+                        ?>
+                            <div class="lecturer-nav">
+                                <hr class="nav-divider">
+                                <a class="nav-item link" id="student-management">Student Management</a>
+                                <a class="nav-item link" id="test-management">Test Management</a>
+                            </div>
+                        <?php
+                        }
+                    ?>
+
+                    <?php 
+                        if (isset($_SESSION['accessLevel']) && $_SESSION['accessLevel'] === "ADMIN") {
+                        ?>
+                            <div class="admin-nav">
+                                <hr class="nav-divider">
+                                <a class="nav-item link" id="lecturer-management">Lecturer Management</a>
+                            </div>
+                        <?php
+                        }
+                    ?>
                 </nav>
 
                 <!-- Drop up -->

--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@
     require_once ("php/_connect.php");
 
     // Establishing routing variables ($routerOptions order: debugMode, urlPrefix, cspLevel, forceTrailingSlash).
-    $routerOptions = new RouterOptions(false, '/inq/Inquizitive', 'none', false);
+    $routerOptions = new RouterOptions(false, '/Inquizitive', 'none', false);
     $route = new jRoute($routerOptions);
 
     // Default route.


### PR DESCRIPTION
Protect dashboard navigation links by checking $_SESSION['accessLevel']: show lecturer links only to LECTURER or ADMIN, and show lecturer-management only to ADMIN (contents/dashboardNavigation.php). Also adjust the router URL prefix from '/inq/Inquizitive' to '/Inquizitive' to correct the routing base (index.php).