### PR TITLE
Mt changes after tech demo

### DIFF
--- a/contents/includes/admLecturerManagement.php
+++ b/contents/includes/admLecturerManagement.php
@@ -244,7 +244,7 @@ $stmt->close();
                       <td class="text-end">
                         <div class="lm-actions">
                           <!-- Edit Button -->
-                          <button class="btn btn-sm btn-outline-primary">Edit</button>
+                          <button class="btn btn-sm btn-outline-primary smEditBtn" data-useruuid="<?= htmlspecialchars($uuid) ?>">Edit</button>
                           <!-- Disable/Enable Button -->
                           <button class="btn btn-sm btn-outline-warning lmToggleDisableBtn" data-useruuid="<?= htmlspecialchars($uuid) ?>" data-disabled="<?= $isDisabled?>">
                             <?= $isDisabled ? "Enable" : "Disable" ?>
@@ -269,6 +269,25 @@ $stmt->close();
 </div>
 
 <script>
+
+//Mihael edit btn stuff
+$(".smEditBtn").ready(function (){
+  $(".smEditBtn").click(function (){
+    $.ajax({
+      url: './edit-lecturer', 
+      type: 'POST', 
+      data: { userUUID: $(this).attr("data-useruuid").toString() },
+      success: function(response) {
+      //console.log('Success:', response);
+        $("#content").html(response);
+      },
+      error: function(xhr, status, error) {
+        //console.log('Error:', error);
+      }
+    });            
+  })
+})
+
 document.addEventListener("submit", async (e) => {
   if (e.target.id !== "lmAddLecturerForm") return;
 

--- a/contents/includes/admSubjectManagement.php
+++ b/contents/includes/admSubjectManagement.php
@@ -213,7 +213,7 @@ $stmt->close();
                       <td class="text-end">
                         <div class="sm-actions">
                           <!-- Edit Button -->
-                          <button class="btn btn-sm btn-outline-primary">Edit</button>
+                          <button class="btn btn-sm btn-outline-primary smEditBtn" data-subjectuuid= <?= htmlspecialchars($subjectUUID) ?>>Edit</button>
                           <!-- Disable/Enable Button -->
                           <button class="btn btn-sm btn-outline-warning smToggleDisableBtn" data-subjectuuid="<?= htmlspecialchars($subjectUUID) ?>" data-disabled="<?= $isDisabled?>">
                             <?= $isDisabled ? "Enable" : "Disable" ?>
@@ -237,6 +237,26 @@ $stmt->close();
 
 <!-- SUBJECT MANAGEMENT: CREATE SUBJECT -->
 <script>
+//Mihael edit btn stuff
+$(".smEditBtn").ready(function (){
+  $(".smEditBtn").click(function (){
+    $.ajax({
+      url: './edit-subject', 
+      type: 'POST', 
+      data: { subjectUUID: $(this).attr("data-subjectuuid").toString() },
+      success: function(response) {
+      //console.log('Success:', response);
+        $("#content").html(response);
+      },
+      error: function(xhr, status, error) {
+        //console.log('Error:', error);
+      }
+    });            
+  })
+})
+
+
+
 document.addEventListener("submit", async (e) => {
   if (e.target.id !== "smAddSubjectForm") return;
 

--- a/contents/includes/editLecturer.php
+++ b/contents/includes/editLecturer.php
@@ -1,0 +1,107 @@
+<?php
+$db = new inquizitiveDB();
+$userUUID = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['userUUID'])); 
+  if ($result = $db->Query("CALL GetUserByUserUUID(?)", [$userUUID])) {
+
+      $rowCount = mysqli_num_rows($result);
+      if ($rowCount > 0) {
+          $row = mysqli_fetch_assoc($result);
+      }
+  }
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link rel="stylesheet" href="./css/editSubject.css" />
+</head>
+<body>
+    <section id="edit-subject">
+        <div id="edit-subject-wrapper" class="shadow">
+          <form id="smAddSubjectForm" class="row g-3 shadow" autocomplete="off" method="post">
+
+            <div class="col-12 hidden">
+              <label class="form-label txt-center" for="smUserUUID">User UUID</label>
+              <input id="smUserUUID" type="text" class="form-control" name="smUserUUID" value ="<?= $userUUID?>" required>
+            </div>
+
+            <div class="col-12">
+              <label class="form-label txt-center" for="userEmail">User Email</label>
+              <input id="userEmail" type="email" class="form-control" name="userEmail" value ="<?= htmlspecialchars($row['email'])?>" required>
+            </div>
+            <div class="col-12">
+              <label class="form-label txt-center" for="smFirstName">First Name</label>
+              <input id="smFirstName" type="text" class="form-control" name="firstName" value ="<?= htmlspecialchars($row['firstName'])?>"  required>
+            </div>
+            <div class="col-12">
+              <label class="form-label txt-center" for="smLastName">Last Name</label>
+              <input id="smLastName" type="text" class="form-control" name="lastName" value ="<?= htmlspecialchars($row['lastName'])?>"  required>
+            </div>
+
+            <div class="col-12">
+              <label class="form-label txt-center" for="password">Password</label>
+              <input id="password" type="password" class="form-control" name="password" value ="" placeholder="Leave empty to keep unchanged..." required>
+            </div>
+            <div class="col-12">
+            <label class="form-label txt-center" for="accessLevel">Access Level</label>
+            <select class="form-select form-control" aria-label="Default select example" name="accessLevel" id="accessLevel">
+                <option selected value ="<?= htmlspecialchars($row['accessLevel'])?>"><?= htmlspecialchars($row['accessLevel'])?></option>
+                <option value="USER">USER</option>
+                <option value="LECTURER">LECTURER</option>
+                <option value="ADMIN">ADMIN</option>
+            </select>
+            </div>
+            <div class="col-12">
+                <div class="form-check isDisabledWrapper">
+                    <input class="form-check-input" name ="isDisabled" type="checkbox" value ="<?= htmlspecialchars($row['isDisabled'])?>"  id="isDisabled" <?php if(htmlspecialchars($row['isDisabled']) == 1){echo "checked";};?>>
+                    <label class="form-check-label" for="isDisabled">
+                        Disable Account?
+                    </label>
+                </div>
+            </div>
+            <div class="col-12">
+                <div id="submitBtnWrapper">
+                    <button type="button" class="btn btn-primary form-control" id="smEditBtn">
+                        Edit Account
+                    </button>
+                </div>
+            </div>
+
+
+          </form>
+        </div>
+    </section>
+    <script>
+        $("#smEditBtn").ready(function(){
+            $("#smEditBtn").click(function(e){
+                    $.ajax({
+                    url: './editLecturer', 
+                    type: 'POST', 
+                    data: $("#smAddSubjectForm").serialize(),
+                    success: function(responseOne) {
+                        console.log('Success:', responseOne);
+                    $.ajax({
+                        url: './lecturer-management', 
+                        type: 'GET', 
+                        success: function(response) {
+                            //console.log('Success:', response);
+                            $("#content").html(response);
+                        },
+                        error: function(xhr, status, error) {
+                            //console.log('Error:', error);
+                        }
+                    });
+                    },
+                    error: function(xhr, status, error) {
+                        console.log('Error:', error);
+                    }
+                });
+            })
+        })
+    </script>
+
+</body>
+</html>

--- a/contents/includes/editLecturer.php
+++ b/contents/includes/editLecturer.php
@@ -51,7 +51,6 @@ $userUUID = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['user
                 <option selected value ="<?= htmlspecialchars($row['accessLevel'])?>"><?= htmlspecialchars($row['accessLevel'])?></option>
                 <option value="USER">USER</option>
                 <option value="LECTURER">LECTURER</option>
-                <option value="ADMIN">ADMIN</option>
             </select>
             </div>
             <div class="col-12">

--- a/contents/includes/editSubject.php
+++ b/contents/includes/editSubject.php
@@ -1,0 +1,95 @@
+<?php
+$db = new inquizitiveDB();
+$subjectUUID = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['subjectUUID'])); 
+  if ($result = $db->Query("CALL GetSubject(?)", [$subjectUUID])) {
+
+      $rowCount = mysqli_num_rows($result);
+      if ($rowCount > 0) {
+          $row = mysqli_fetch_assoc($result);
+      }
+  }
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <link rel="stylesheet" href="./css/editSubject.css" />
+</head>
+<body>
+    <section id="edit-subject">
+        <div id="edit-subject-wrapper" class="shadow">
+          <form id="smAddSubjectForm" class="row g-3 shadow" autocomplete="off" method="post">
+
+            <div class="col-12 hidden">
+              <label class="form-label txt-center" for="smSubjectUUID">Subject UUID</label>
+              <input id="smSubjectUUID" type="text" class="form-control" name="subjectUUID" value ="<?= $subjectUUID?>" required>
+            </div>
+
+            <div class="col-12">
+              <label class="form-label txt-center" for="smFirstName">Subject Name</label>
+              <input id="smFirstName" type="text" class="form-control" name="subjectName" value ="<?= htmlspecialchars($row['subjectTitle'])?>" required>
+            </div>
+
+            <div class="col-12">
+              <label class="form-label txt-center" for="smLastName">Subject Description</label>
+              <input id="smLastName" type="text" class="form-control" name="subjectDescription" value ="<?= htmlspecialchars($row['subjectDescription'])?>"  required>
+            </div>
+
+            <div class="col-12">
+              <label class="form-label txt-center" for="smAuthord">Author</label>
+              <input id="smAuthord" type="text" class="form-control" name="author" value ="<?= htmlspecialchars($row['authorUUID'])?>"  disabled>
+            </div>
+            <div class="col-12">
+                <div class="form-check isDisabledWrapper">
+                    <input class="form-check-input" name ="isDisabled" type="checkbox" value ="<?= htmlspecialchars($row['isDisabled'])?>"  id="isDisabled" <?php if(htmlspecialchars($row['isDisabled']) == 1){echo "checked";};?>>
+                    <label class="form-check-label" for="isDisabled">
+                        Disable Account?
+                    </label>
+                </div>
+            </div>
+            <div class="col-12">
+                <div id="submitBtnWrapper">
+                    <button type="button" class="btn btn-primary form-control" id="smEditBtn">
+                        Edit Subject
+                    </button>
+                </div>
+            </div>
+
+
+          </form>
+        </div>
+    </section>
+    <script>
+        $("#smEditBtn").ready(function(){
+            $("#smEditBtn").click(function(e){
+                    $.ajax({
+                    url: './editSubject', 
+                    type: 'POST', 
+                    data: $("#smAddSubjectForm").serialize(),
+                    success: function(responseOne) {
+                        console.log('Success:', responseOne);
+                    $.ajax({
+                        url: './subject-management', 
+                        type: 'GET', 
+                        success: function(response) {
+                            //console.log('Success:', response);
+                            $("#content").html(response);
+                        },
+                        error: function(xhr, status, error) {
+                            //console.log('Error:', error);
+                        }
+                    });
+                    },
+                    error: function(xhr, status, error) {
+                        console.log('Error:', error);
+                    }
+                });
+            })
+        })
+    </script>
+
+</body>
+</html>

--- a/contents/includes/quizManagement.php
+++ b/contents/includes/quizManagement.php
@@ -7,7 +7,7 @@ require_once("./php/_mtQuizClasses.php");
 $currentQuiz = new quiz();
 $db= new inquizitiveDB ();
 
-$quizUUID = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['grabQuiz']));
+$quizUUID = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['quizGrab']));
 
 
 if ($result = $db->Query("CALL GetQuizQuestionsByID(?);",[$quizUUID])) {

--- a/contents/includes/quizResult.php
+++ b/contents/includes/quizResult.php
@@ -61,10 +61,10 @@ if ($result = $db->Query("CALL GetQuizQuestionsByID(?);",[$quizUUID])) {
         if($answer == $quiz->getQuestions()[$n]->getAnswer())
         {
           $style ="correct";
-          $score +=30;
+          $score = $score + 30;
         }else
         {
-          $score -=10;
+          $score =$score - 10;
           $style="wrong";
         }
 
@@ -103,15 +103,22 @@ if($score > 0){
       if ($rowCount > 0) {
           $row = mysqli_fetch_assoc($result);
           $userCurrency = htmlspecialchars($row['quantity']);
+      }else
+      {
+        // No item found therefore base currency is set to 0
+        $db= new inquizitiveDB ();
+        $userCurrency =0;
+        $result = $db->Query("CALL AddItemToGivenAccountInventory(?,?,?);", [$userUUID,$currencyItemUUID,$userCurrency]);
+
       }
   }
 
-  $db= new inquizitiveDB ();
-  $moneyLeft =  (int)$userCurrency + $score;
-  if($currencyItemUUID && $userUUID && $userCurrency)
+  $moneyLeft =  (int)$userCurrency + (int)$score;
+  if(!is_null($currencyItemUUID) && !is_null($userUUID) && !is_null($userCurrency))
   {
-  $b = $db->Query("CALL SetUserInventoryItemQuantity(?,?,?);", [$userUUID,$currencyItemUUID,$moneyLeft]);
-  echo '<div class="score">you gained ' . $score . " iq points</div>";
+    $db= new inquizitiveDB ();
+    $b = $db->Query("CALL SetUserInventoryItemQuantity(?,?,?);", [$userUUID,$currencyItemUUID,$moneyLeft]);
+    echo '<div class="score">you gained ' . $score . " iq points</div>";
   }
 }
 ?>

--- a/css/editSubject.css
+++ b/css/editSubject.css
@@ -1,0 +1,69 @@
+#content
+{
+    height: 100%;
+    width: 100%;
+}
+#edit-subject
+{
+    height:100%;
+    width: 100%;
+}
+#edit-subject #edit-subject-wrapper
+{
+    position: relative;
+    display: grid;
+
+    justify-items: center;
+    align-items: center;
+    justify-content: center;
+    place-items:  center;
+    border-radius: 5px;
+    min-width:100% !important;
+    min-height: 100% !important;
+    overflow: hidden;
+    background-color: var(--c-offwhite);
+}
+#edit-subject-wrapper .txt-center
+{
+    width:100%;
+    text-align: center;
+
+}
+#edit-subject #isDisabled
+{
+    position:relative;
+}
+#edit-subject .isDisabledWrapper
+{
+    position:relative;
+    display:flex;
+    flex-direction: row;
+    width:100%;
+    justify-content: center;
+}
+#edit-subject #submitBtnWrapper
+{
+    width:100%;
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+#edit-subject #smAddSubjectForm
+{
+    border-radius: 5px;
+    max-width: 40%;
+}
+
+#edit-subject #smEditBtn
+{
+    background-color: var( --c-english-violet);
+    width:auto;
+    margin:0;
+    margin-bottom: 20px;
+    padding:5px;
+}
+#edit-subject .hidden
+{
+    display:none;
+}

--- a/css/editSubject.css
+++ b/css/editSubject.css
@@ -21,7 +21,7 @@
     min-width:100% !important;
     min-height: 100% !important;
     overflow: hidden;
-    background-color: var(--c-offwhite);
+    background-color: #ffffff;
 }
 #edit-subject-wrapper .txt-center
 {
@@ -53,6 +53,8 @@
 {
     border-radius: 5px;
     max-width: 40%;
+    background-color: #ffffff;
+
 }
 
 #edit-subject #smEditBtn

--- a/index.php
+++ b/index.php
@@ -55,7 +55,8 @@
     $route->Route(['post'], '/shop-buy-item', "./contents/includes/shopBuyItem.php");
     $route->Route(['post'], '/editSubject', "./php/editSubject.php");
     $route->Route(['post'], '/edit-subject', "./contents/includes/editSubject.php");
-
+    $route->Route(['post'], '/editLecturer', "./php/editLecturer.php");
+    $route->Route(['post'], '/edit-lecturer', "./contents/includes/editLecturer.php");
 
     $route->Route(['get'], '/last-page', "./contents/includes/pageSession.php");
     $route->Route(['get'], '/logout', "./php/logout.php");

--- a/index.php
+++ b/index.php
@@ -53,6 +53,8 @@
     $route->Route(['get'], '/shop-items', "./contents/includes/shopItemsPage.php");
     $route->Route(['get'], '/shop-gacha', "./contents/includes/gachaItemsPage.php");
     $route->Route(['post'], '/shop-buy-item', "./contents/includes/shopBuyItem.php");
+    $route->Route(['post'], '/editSubject', "./php/editSubject.php");
+    $route->Route(['post'], '/edit-subject', "./contents/includes/editSubject.php");
 
 
     $route->Route(['get'], '/last-page', "./contents/includes/pageSession.php");

--- a/php/editLecturer.php
+++ b/php/editLecturer.php
@@ -1,0 +1,42 @@
+<?php
+echo var_dump($_POST);
+
+$db = new inquizitiveDB();
+$userUUID = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['smUserUUID'])); 
+$firstName = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['firstName'])); 
+$lastName = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['lastName'])); 
+$email = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['userEmail'])); 
+$accessLevel = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['accessLevel'])); 
+$isDisabled =0;
+if(isset($_POST['isDisabled']))
+{
+    $isDisabled = 1; 
+
+}
+
+if(isset($_POST['password']) && $_POST['password'] !=="" && $_POST['password'] !== " ")
+{
+    echo"password set";
+$password = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['password'])); 
+$hash = password_hash($password, PASSWORD_BCRYPT);
+  if ($result = $db->Query("CALL UpdateUserByUserUUID(?,?,?,?,?,?,?)", [$userUUID,$email,$firstName,$lastName,$hash,$accessLevel,$isDisabled])) {
+
+      $rowCount = mysqli_num_rows($result);
+      if ($rowCount > 0) {
+          $row = mysqli_fetch_assoc($result);
+      }
+  }
+}else
+{
+    echo"password not set";
+      if ($result = $db->Query("CALL UpdateUserByUserUUIDNoPassword(?,?,?,?,?,?)", [$userUUID,$email,$firstName,$lastName,$accessLevel,$isDisabled])) {
+
+      $rowCount = mysqli_num_rows($result);
+      if ($rowCount > 0) {
+          $row = mysqli_fetch_assoc($result);
+      }
+  }
+}
+
+
+?>

--- a/php/editSubject.php
+++ b/php/editSubject.php
@@ -1,0 +1,21 @@
+<?php
+echo var_dump($_POST);
+
+$db = new inquizitiveDB();
+$subjectUUID = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['subjectUUID'])); 
+$subjectTitle = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['subjectName'])); 
+$subjectDescription = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['subjectDescription'])); 
+$isDisabled =0;
+if(isset($_POST['isDisabled']))
+{
+    $isDisabled = 1; 
+
+}
+  if ($result = $db->Query("CALL EditSubject(?,?,?,?)", [$subjectUUID,$subjectTitle,$subjectDescription,$isDisabled])) {
+
+      $rowCount = mysqli_num_rows($result);
+      if ($rowCount > 0) {
+          $row = mysqli_fetch_assoc($result);
+      }
+  }
+?>


### PR DESCRIPTION
<img width="1898" height="923" alt="image" src="https://github.com/user-attachments/assets/89dda19c-2e33-44ed-b128-daea9e03f137" />
Subject management edit button now works to hydrate content with a new form. Created new files with html, data retrieval and submission to database using prepared statements and procedures. Form is then using the jQuery.serialize() function for fast development time and content is hydrated back with the previous page for a smooth UX.

<img width="1897" height="940" alt="image" src="https://github.com/user-attachments/assets/acbd149b-8109-482a-8bed-4e3be7bd1122" />
Lecturer management edit button now fully functional as well, with custom files created for the serverside and styling for the form on the front end.

Both lecturer management and subject management edit use variable names, and same form html with some extensive edits from their respective management pages with editing for data retrieval and submission for page cohesion.

Both lecturer and subject management hydrate back their respective pages and show correctly updated fields.
Lecturer management even considers if the password is left empty to edit everything else but the password. This way the edit field  will not show user passwords and they can remain untouched, or if edited then hashed again and stored in the database with procedures. 

<img width="1897" height="932" alt="image" src="https://github.com/user-attachments/assets/37ce758f-8111-4fe7-833c-ac33b82ffa36" />
IQ points now being given correctly.
