### PR TITLE
Test Selection Page + Editing Student Accounts

### DIFF
--- a/contents/dashboardNavigation.php
+++ b/contents/dashboardNavigation.php
@@ -5,6 +5,22 @@
 if (!defined('IN_DASHBOARD_SHELL')) {
     define('IN_DASHBOARD_SHELL', true);
 }
+
+
+$userIcon ="";
+require_once("./php/_connect.php");
+$db = new inquizitiveDB();
+$userUUID = htmlspecialchars($_SESSION['userUUID']);
+
+$result = $db->Query("CALL GetUserByUserUUID(?)",[$userUUID]);
+$row = mysqli_fetch_assoc($result);
+$userIcon = htmlspecialchars($row['avatar']);
+
+
+
+$first = $_SESSION['firstName'];
+$last = $_SESSION["lastName"];
+$initials = mb_strtoupper($first[0] . $last[0]);
 ?>
 
 <head>
@@ -75,7 +91,19 @@ if (!defined('IN_DASHBOARD_SHELL')) {
                 <hr class="dropup-divider">
                 <button class="profile-trigger" id="profileTrigger" type="button" aria-haspopup="true" aria-expanded="false">
                     <div class="profile">
-                    <div class="avatar"></div>
+                        <img
+                        src="<?php
+                            if($userIcon !== "" && $userIcon !== " " && $userIcon !== NULL)
+                            {
+                                echo $userIcon;
+                            }else
+                            {
+                                echo "https://proficon.appserver.uk/api/initials/" . htmlspecialchars($initials);
+                            } 
+                        ?>"
+                        alt="Profile picture"
+                        class="avatar"
+                        />
                     <div class="profile-info">
                         <div class="name"><span><?php echo htmlspecialchars($_SESSION['firstName']);echo " ";echo htmlspecialchars($_SESSION['lastName']);?></span></div>
                         <div class="role"><?php echo htmlspecialchars($_SESSION['accessLevel'])?></span></div>

--- a/contents/includes/quizManagement.php
+++ b/contents/includes/quizManagement.php
@@ -375,16 +375,29 @@ $updated    = htmlspecialchars($quizMeta['lastUpdated'] ?? '', ENT_QUOTES, 'UTF-
       Swal.fire({ icon: "error", title: "Delete failed", text: (e.responseText || "Unknown error") });
     }
   });
+</script>
 
-  $(document).on("click", "#backBtn", function(){
+<script>
+$(document).on("click", "#backBtn", function (e) {
+  e.preventDefault();
 
   $.ajax({
-    url: "./test-management", // your original list page
+    url: "./test-management",
     type: "POST",
-    success: function(response){
+    headers: {
+      "X-Requested-With": "XMLHttpRequest"
+    },
+    success: function (response) {
       $("#content").html(response);
+    },
+    error: function (xhr, status, error) {
+      console.error("Failed to load quiz management page:", error);
+      Swal.fire({
+        icon: "error",
+        title: "Could not go back",
+        text: "Failed to load the quiz management page."
+      });
     }
   });
-
 });
 </script>

--- a/contents/includes/quizzesPage.php
+++ b/contents/includes/quizzesPage.php
@@ -55,7 +55,7 @@ $userUUID = $_SESSION['userUUID'] ?? null;
 
       <div class="row g-3">
         <?php
-          if ($result = $db->Query("CALL GetAllQuizzes();", [])) {
+          if ($result = $db->Query("CALL GetQuizzesBySubjectLink(?);", [$userUUID])) {
             if (mysqli_num_rows($result) > 0) {
               while($row = mysqli_fetch_assoc($result)) {
 

--- a/contents/includes/quizzesPage.php
+++ b/contents/includes/quizzesPage.php
@@ -1,4 +1,3 @@
-
 <?php
 
 // include __DIR__ . "/../../php/blockDirectAccess.php";
@@ -14,103 +13,224 @@ if (!$isAjax && !$isEmbeddedInDashboard) {
   exit;
 }
 
+require_once("./php/_connect.php");
+$db = new inquizitiveDB();
+$conn = $db->connect;
+
+// You will probably already have this in session
+// change this to however you store the logged in user UUID
+$userUUID = $_SESSION['userUUID'] ?? null;
 ?>
 
-
 <style>
-#quizzesPage .quizCard{
-border-radius: 16px;
-transition: transform .12s ease, box-shadow .12s ease;
-}
-#quizzesPage .quizCard:hover{
-transform: translateY(-2px);
-box-shadow: 0 12px 30px rgba(0,0,0,.10) !important;
-}
-#quizzesPage .btn-primary{
-border-radius: 12px;
-padding: 10px 14px;
-font-weight: 600;
-background-color:#524A71;
-}
-</style>
 
+</style>
 
 <section id="quizzesPage" class="container py-4">
 
   <div class="d-flex flex-wrap align-items-end justify-content-between gap-3 mb-4">
     <div>
       <h2 class="mb-1">Quizzes</h2>
-      <p class="text-muted mb-0">Pick a quiz to begin.</p>
+      <p class="text-muted mb-0">Take a new quiz or view quizzes you have already completed.</p>
     </div>
 
-    <div class="input-group" style="max-width: 360px;">
-	
+    <div class="tab-switcher" role="tablist" aria-label="Quiz sections">
+      <button type="button" class="btn btn-outline-primary active quiz-tab-btn" data-target="availablePanel">
+        Quizzes
+      </button>
+      <button type="button" class="btn btn-outline-primary quiz-tab-btn" data-target="completedPanel">
+        Completed
+      </button>
     </div>
   </div>
 
-  <div class="row g-3" id="quizGrid">
-    <?php
-      require_once("./php/_connect.php");
-      $db = new inquizitiveDB();
+  <div class="quiz-panels-wrapper">
 
-      if ($result = $db->Query("CALL GetAllQuizzes();", [])) {
-        if (mysqli_num_rows($result) > 0) {
-          while($row = mysqli_fetch_assoc($result)) {
+    <!-- AVAILABLE QUIZZES -->
+    <div id="availablePanel" class="quiz-panel is-active">
+      <div class="mb-3">
+        <h5 class="mb-1">Available quizzes</h5>
+        <p class="section-subtitle">Pick a quiz to begin.</p>
+      </div>
 
-            // If you have a quizName column, this will use it, otherwise fallback:
-            $quizTitle = !empty($row['quizName']) ? $row['quizName'] : "Quiz";
+      <div class="row g-3">
+        <?php
+          if ($result = $db->Query("CALL GetAllQuizzes();", [])) {
+            if (mysqli_num_rows($result) > 0) {
+              while($row = mysqli_fetch_assoc($result)) {
 
-            echo '
-              <div class="col-12 col-md-6 col-lg-4 quiz-card" data-title="'.htmlspecialchars(strtolower($quizTitle)).'" data-uuid="'.htmlspecialchars(strtolower($row["quizUUID"])).'">
-                <div class="card shadow-sm border-0 h-100 quizCard">
-                  <div class="card-body d-flex flex-column">
-                    <div class="d-flex align-items-start justify-content-between gap-2">
-                      <div>
-                        <h5 class="card-title mb-1">'.htmlspecialchars($quizTitle).'</h5>
-                        <div class="small text-muted">Quiz ID: <span class="font-monospace">'.htmlspecialchars($row["quizUUID"]).'</span></div>
+                $quizTitle = !empty($row['quizName']) ? $row['quizName'] : "Quiz";
+                  $subjectName = !empty($row['subjectTitle']) ? $row['subjectTitle'] : 'No Subject';
+
+                echo '
+                  <div class="col-12 col-md-6 col-lg-4 quiz-card" data-title="'.htmlspecialchars(strtolower($quizTitle)).'" data-uuid="'.htmlspecialchars(strtolower($row["quizUUID"])).'">
+                    <div class="card shadow-sm border-0 h-100 quizCard">
+                      <div class="card-body d-flex flex-column">
+                        <div class="d-flex align-items-start justify-content-between gap-2">
+                          <div>
+                            <h5 class="card-title mb-1">'.htmlspecialchars($quizTitle).'</h5>
+                            <div class="small text-muted">Subject: <span class="font-monospace">'.htmlspecialchars($subjectName).'</span></div>
+                          </div>
+                          <span class="badge rounded-pill text-bg-light border">Easy</span>
+                        </div>
+
+                        <div class="mt-3 text-muted small">
+                          '.(int)$row['questionCount'].' questions • Multiple choice
+                        </div>
+
+                        <div class="mt-auto pt-3 d-grid">
+                          <button id="' . htmlspecialchars($row['quizUUID']) . '" class="take-quiz-btn btn btn-primary">
+                            Take quiz
+                          </button>
+                        </div>
                       </div>
-                      <span class="badge rounded-pill text-bg-light border">Easy</span>
-                    </div>
-
-                    <div class="mt-3 text-muted small">
-                      10 questions • Multiple choice
-                    </div>
-
-                    <div class="mt-auto pt-3 d-grid">
-
-					  <button id="' . htmlspecialchars($row['quizUUID']) . '" class ="take-quiz-btn btn btn-primary" >Take quiz</button>
                     </div>
                   </div>
-                </div>
-              </div>
-            ';
+                ';
+              }
+            } else {
+              echo '<div class="col-12"><div class="alert alert-warning mb-0">No quizzes found.</div></div>';
+            }
+
+            mysqli_free_result($result);
+            while (mysqli_more_results($conn) && mysqli_next_result($conn)) {
+              $extra = mysqli_store_result($conn);
+              if ($extra) mysqli_free_result($extra);
+            }
+          } else {
+            echo '<div class="col-12"><div class="alert alert-danger mb-0">Failed to load quizzes.</div></div>';
           }
-        } else {
-          echo '<div class="col-12"><div class="alert alert-warning mb-0">No quizzes found.</div></div>';
-        }
-      } else {
-        echo '<div class="col-12"><div class="alert alert-danger mb-0">Failed to load quizzes.</div></div>';
-      }
-    ?>
+        ?>
+      </div>
+    </div>
+
+    <!-- COMPLETED QUIZZES -->
+    <div id="completedPanel" class="quiz-panel is-hidden">
+      <div class="mb-3">
+        <h5 class="mb-1">Completed quizzes</h5>
+        <p class="section-subtitle">View quizzes you have already taken.</p>
+      </div>
+
+      <div class="row g-3">
+        <?php
+          if ($userUUID) {
+
+            if ($completedResult = $db->Query("CALL GetCompletedQuizzesByUserUUID(?);", [$userUUID])) {
+              if (mysqli_num_rows($completedResult) > 0) {
+                while($row = mysqli_fetch_assoc($completedResult)) {
+
+                  $quizTitle = !empty($row['quizName']) ? $row['quizName'] : 'Completed Quiz';
+                  $score = isset($row['score']) ? $row['score'] . '%' : 'Completed';
+                  $completedDate = !empty($row['completionDate']) ? $row['completionDate'] : 'Unknown date';
+                  $dateFormatted = date("d/m/Y", strtotime($completedDate));
+
+                  $subjectName = !empty($row['subjectTitle']) ? $row['subjectTitle'] : 'No Subject';
+
+
+                  echo '
+                    <div class="col-12 col-md-6 col-lg-4">
+                      <div class="card shadow-sm border-0 h-100 quizCard">
+                        <div class="card-body d-flex flex-column">
+                          <div class="d-flex align-items-start justify-content-between gap-2">
+                            <div>
+                              <h5 class="card-title mb-1">'.htmlspecialchars($quizTitle).'</h5>
+                              <div class="small text-muted">Subject: <span class="font-monospace">'.htmlspecialchars($subjectName).'</span></div>
+                            </div>
+                            <span class="result-pill">'.htmlspecialchars($score).'</span>
+                          </div>
+
+                          <div class="mt-3 text-muted small">
+                            Completed on: '.htmlspecialchars($dateFormatted).'
+                          </div>
+
+                          <div class="mt-auto pt-3 d-grid">
+                            <button
+                              class="review-quiz-btn btn btn-outline-primary"
+                              data-quiz-id="'.htmlspecialchars($row['quizUUID']).'">
+                              View attempt
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ';
+                }
+              } else {
+                echo '<div class="col-12"><div class="alert alert-info mb-0">You have not completed any quizzes yet.</div></div>';
+              }
+
+              mysqli_free_result($completedResult);
+              while (mysqli_more_results($conn) && mysqli_next_result($conn)) {
+                $extra = mysqli_store_result($conn);
+                if ($extra) mysqli_free_result($extra);
+              }
+            } else {
+              echo '<div class="col-12"><div class="alert alert-danger mb-0">Failed to load completed quizzes.</div></div>';
+            }
+          } else {
+            echo '<div class="col-12"><div class="alert alert-warning mb-0">User not found in session.</div></div>';
+          }
+        ?>
+      </div>
+    </div>
+
   </div>
 </section>
 
-    <script> // Move to scriptName.js
-        $(".take-quiz-btn").ready(function(){
-            $(".take-quiz-btn").click(function(){
-                $.ajax({
-                    url: './testing', 
-                    type: 'POST', 
-                    data: { quizID: $(this).attr("id").toString(), key2: 'test' },
-                    success: function(response) {
-                        //console.log('Success:', response);
-                        $("#content").html(response);
-                    },
-                    error: function(xhr, status, error) {
-                        //console.log('Error:', error);
-                    }
-                });
-            })
-        })
+<script>
+  // FUNCTION TO SWAP TO COMPLETED
+$(document).ready(function () {
+  $('.quiz-tab-btn').on('click', function () {
+    const targetId = $(this).data('target');
+    const $target = $('#' + targetId);
+    const $current = $('.quiz-panel.is-active');
 
-    </script>
+    if ($target[0] === $current[0]) return;
+
+    $('.quiz-tab-btn').removeClass('active');
+    $(this).addClass('active');
+
+    $current.removeClass('is-active').addClass('to-left');
+
+    setTimeout(function () {
+      $current.removeClass('to-left').addClass('is-hidden');
+      $target.removeClass('is-hidden').addClass('is-active');
+    }, 140);
+  });
+
+  // TAKE QUIZ BUTTON
+  $(document).on('click', '.take-quiz-btn', function () {
+    $.ajax({
+      url: './testing',
+      type: 'POST',
+      data: {
+        quizID: $(this).attr('id').toString(),
+        key2: 'test'
+      },
+      success: function (response) {
+        $('#content').html(response);
+      },
+      error: function (xhr, status, error) {
+        console.log('Error:', error);
+      }
+    });
+  });
+
+  // review completed quiz
+  $(document).on('click', '.review-quiz-btn', function () {
+    $.ajax({
+      url: './reviewQuizAttempt',
+      type: 'POST',
+      data: {
+        quizID: $(this).data('quiz-id').toString()
+      },
+      success: function (response) {
+        $('#content').html(response);
+      },
+      error: function (xhr, status, error) {
+        console.log('Error:', error);
+      }
+    });
+  });
+});
+</script>

--- a/contents/includes/settingsPage.php
+++ b/contents/includes/settingsPage.php
@@ -18,6 +18,11 @@ require_once __DIR__ . "/../../php/_connect.php";
 $db = new inquizitiveDB();
 $conn = $db->connect;
 
+$userUUID = htmlspecialchars($_SESSION['userUUID']);
+$result = $db->Query("CALL GetUserByUserUUID(?)",[$userUUID]);
+$row = mysqli_fetch_assoc($result);
+$userIcon = htmlspecialchars($row['avatar']);
+
 ?>
 
 <div id="adminDashboard" class="container-fluid py-4">
@@ -138,11 +143,20 @@ $conn = $db->connect;
                 $userCreationDateFormatted = date("d-m-Y", strtotime($userCreationDate));
                 $initials = mb_strtoupper($first[0] . $last[0]);
             ?>
-            <img
-              src="https://proficon.appserver.uk/api/initials/<?= htmlspecialchars($initials) ?>.svg"alt="<?= htmlspecialchars($initials) ?>"
+              <img
+              src="<?php
+                  if($userIcon !== "" && $userIcon !== " " && $userIcon !== NULL)
+                  {
+                      echo $userIcon;
+                  }else
+                  {
+                      echo "https://proficon.appserver.uk/api/initials/" . htmlspecialchars($initials);
+                  } 
+              ?>"
               alt="Profile picture"
+              class="avatar"
               style="width:72px;height:72px;border-radius:16px;object-fit:cover;"
-            />
+              />
             <div class="flex-grow-1">
               <div class="d-flex align-items-center gap-2 flex-wrap">
                 <div class="h5 mb-0"><?= htmlspecialchars($firstFormatted . " " . $lastFormatted) ?></div>

--- a/contents/includes/studentManagement.php
+++ b/contents/includes/studentManagement.php
@@ -1,7 +1,5 @@
 <?php
 
-// include __DIR__ . "/../../php/blockDirectAccess.php";
-
 $isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
           strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
 
@@ -18,8 +16,14 @@ require_once __DIR__ . "/../../php/_connect.php";
 $db = new inquizitiveDB();
 $conn = $db->connect;
 
+$students = [];
+$subjects = [];
 
+/* Get students */
 $stmt = $conn->prepare("CALL GetStudents()");
+if (!$stmt) {
+  die("Prepare failed for GetStudents(): " . $conn->error);
+}
 
 $stmt->execute();
 
@@ -28,6 +32,33 @@ if ($res1 = $stmt->get_result()) {
     $students[] = $row;
   }
   $res1->free();
+}
+$stmt->close();
+
+while (mysqli_more_results($conn) && mysqli_next_result($conn)) {
+  $extra = mysqli_store_result($conn);
+  if ($extra) mysqli_free_result($extra);
+}
+
+/* Get subjects */
+$stmt2 = $conn->prepare("CALL GetAllActiveSubjects()");
+if (!$stmt2) {
+  die("Prepare failed for GetAllActiveSubjects(): " . $conn->error);
+}
+
+$stmt2->execute();
+
+if ($res2 = $stmt2->get_result()) {
+  while ($row = $res2->fetch_assoc()) {
+    $subjects[] = $row;
+  }
+  $res2->free();
+}
+$stmt2->close();
+
+while (mysqli_more_results($conn) && mysqli_next_result($conn)) {
+  $extra = mysqli_store_result($conn);
+  if ($extra) mysqli_free_result($extra);
 }
 ?>
 
@@ -118,7 +149,7 @@ if ($res1 = $stmt->get_result()) {
               <thead>
                 <tr>
                   <th>First Name</th>
-                  <th>Last Name</th>
+                  <th>Email</th>
                   <th>Status</th>
                   <th class="text-end">Actions</th>
                 </tr>
@@ -160,7 +191,14 @@ if ($res1 = $stmt->get_result()) {
                       <td class="text-end">
                         <div class="sdm-actions">
                           <!-- Edit Button -->
-                          <button class="btn btn-sdm btn-outline-primary">Edit</button>
+                          <button
+                            class="btn btn-sdm btn-outline-primary sdmEditStudentBtn"
+                            data-useruuid="<?= htmlspecialchars($userUUID) ?>"
+                            data-firstname="<?= htmlspecialchars($firstName) ?>"
+                            data-lastname="<?= htmlspecialchars($lastName) ?>"
+                            data-email="<?= htmlspecialchars($email) ?>">
+                            Edit
+                          </button>
                           <!-- Disable/Enable Button -->
                           <button class="btn btn-sdm btn-outline-warning smToggleDisableBtn" data-userUUID="<?= htmlspecialchars($userUUID) ?>" data-disabled="<?= $isDisabled?>">
                             <?= $isDisabled ? "Enable" : "Disable" ?>
@@ -401,3 +439,253 @@ document.addEventListener("submit", async (e) => {
   });
 
   </script>
+
+<script>
+const sdmSubjects = <?= json_encode($subjects) ?>;
+
+document.addEventListener("click", async (e) => {
+  const btn = e.target.closest(".sdmEditStudentBtn");
+  if (!btn) return;
+
+  const userUUID = btn.dataset.useruuid;
+  const firstName = btn.dataset.firstname;
+  const lastName = btn.dataset.lastname;
+  const email = btn.dataset.email;
+
+  let enrolledSubjects = [];
+
+  try {
+    const fd = new FormData();
+    fd.append("userUUID", userUUID);
+
+    const res = await fetch("./get-student-subjects", {
+      method: "POST",
+      body: fd,
+      headers: { "X-Requested-With": "XMLHttpRequest" }
+    });
+
+    const data = await res.json();
+
+    if (data.ok && Array.isArray(data.subjects)) {
+      enrolledSubjects = data.subjects;
+    }
+  } catch (err) {
+    console.error("Failed to load student subjects", err);
+  }
+
+  const buildSubjectOptions = () => {
+    let html = `<option value="">Select subject</option>`;
+
+    sdmSubjects.forEach(subject => {
+      const alreadyEnrolled = enrolledSubjects.some(es => es.subjectUUID === subject.subjectUUID);
+      if (!alreadyEnrolled) {
+        html += `<option value="${subject.subjectUUID}">${subject.subjectTitle}</option>`;
+      }
+    });
+
+    return html;
+  };
+
+  const buildEnrolledTable = () => {
+    if (enrolledSubjects.length === 0) {
+      return `<tr><td colspan="2" class="text-muted text-center py-3">No enrolled subjects.</td></tr>`;
+    }
+
+    return enrolledSubjects.map(subject => `
+      <tr>
+        <td>${subject.subjectTitle}</td>
+        <td class="text-end">
+          <button type="button"
+                  class="btn btn-sm btn-outline-danger sdmRemoveSubjectBtn"
+                  data-subjectuuid="${subject.subjectUUID}">
+            Remove
+          </button>
+        </td>
+      </tr>
+    `).join("");
+  };
+
+  const renderModalHtml = () => `
+    <div class="text-start">
+
+      <div class="row g-3 mb-3">
+        <div class="col-12 col-md-6">
+          <label class="form-label fw-semibold">First Name</label>
+          <input id="swalStudentFirstName" class="form-control" value="${firstName}">
+        </div>
+
+        <div class="col-12 col-md-6">
+          <label class="form-label fw-semibold">Last Name</label>
+          <input id="swalStudentLastName" class="form-control" value="${lastName}">
+        </div>
+
+        <div class="col-12">
+          <label class="form-label fw-semibold">Email</label>
+          <input id="swalStudentEmail" class="form-control" value="${email}">
+        </div>
+      </div>
+
+      <hr>
+
+      <div class="mb-3">
+        <label class="form-label fw-semibold">Add Subject</label>
+        <div class="d-flex gap-2">
+          <select id="swalSubjectUUID" class="form-select">
+            ${buildSubjectOptions()}
+          </select>
+          <button type="button" class="btn btn-primary" id="swalAddSubjectBtn">+</button>
+        </div>
+      </div>
+
+      <div>
+        <label class="form-label fw-semibold">Enrolled Subjects</label>
+        <div class="table-responsive">
+          <table class="table table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th>Subject</th>
+                <th class="text-end">Action</th>
+              </tr>
+            </thead>
+            <tbody id="swalEnrolledSubjectsBody">
+              ${buildEnrolledTable()}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+    </div>
+  `;
+
+  const modal = await Swal.fire({
+    title: "Edit Student",
+    html: renderModalHtml(),
+    width: 800,
+    showCancelButton: true,
+    confirmButtonText: "Save Changes",
+    didOpen: () => {
+      const popup = Swal.getPopup();
+
+      popup.addEventListener("click", async (event) => {
+        const addBtn = event.target.closest("#swalAddSubjectBtn");
+        const removeBtn = event.target.closest(".sdmRemoveSubjectBtn");
+
+        if (addBtn) {
+          const select = popup.querySelector("#swalSubjectUUID");
+          const subjectUUID = select.value;
+
+          if (!subjectUUID) {
+            Swal.showValidationMessage("Please select a subject.");
+            return;
+          }
+
+          try {
+            const fd = new FormData();
+            fd.append("userUUID", userUUID);
+            fd.append("subjectUUID", subjectUUID);
+
+            const res = await fetch("./add-student-subject", {
+              method: "POST",
+              body: fd,
+              headers: { "X-Requested-With": "XMLHttpRequest" }
+            });
+
+            const data = await res.json();
+
+            if (!data.ok) {
+              await Swal.fire("Error", data.message || "Failed to add subject.", "error");
+              return;
+            }
+
+            const addedSubject = sdmSubjects.find(s => s.subjectUUID === subjectUUID);
+            if (addedSubject) {
+              enrolledSubjects.push(addedSubject);
+            }
+
+            popup.querySelector("#swalSubjectUUID").innerHTML = buildSubjectOptions();
+            popup.querySelector("#swalEnrolledSubjectsBody").innerHTML = buildEnrolledTable();
+
+          } catch (err) {
+            console.error(err);
+            await Swal.fire("Error", "Server error.", "error");
+          }
+        }
+
+        if (removeBtn) {
+          const subjectUUID = removeBtn.dataset.subjectuuid;
+
+          try {
+            const fd = new FormData();
+            fd.append("userUUID", userUUID);
+            fd.append("subjectUUID", subjectUUID);
+
+            const res = await fetch("./remove-student-subject", {
+              method: "POST",
+              body: fd,
+              headers: { "X-Requested-With": "XMLHttpRequest" }
+            });
+
+            const data = await res.json();
+
+            if (!data.ok) {
+              await Swal.fire("Error", data.message || "Failed to remove subject.", "error");
+              return;
+            }
+
+            enrolledSubjects = enrolledSubjects.filter(s => s.subjectUUID !== subjectUUID);
+
+            popup.querySelector("#swalSubjectUUID").innerHTML = buildSubjectOptions();
+            popup.querySelector("#swalEnrolledSubjectsBody").innerHTML = buildEnrolledTable();
+
+          } catch (err) {
+            console.error(err);
+            await Swal.fire("Error", "Server error.", "error");
+          }
+        }
+      });
+    },
+    preConfirm: async () => {
+      const firstNameValue = document.getElementById("swalStudentFirstName").value.trim();
+      const lastNameValue = document.getElementById("swalStudentLastName").value.trim();
+      const emailValue = document.getElementById("swalStudentEmail").value.trim();
+
+      if (!firstNameValue || !lastNameValue || !emailValue) {
+        Swal.showValidationMessage("All fields are required.");
+        return false;
+      }
+
+      try {
+        const fd = new FormData();
+        fd.append("userUUID", userUUID);
+        fd.append("firstName", firstNameValue);
+        fd.append("lastName", lastNameValue);
+        fd.append("email", emailValue);
+
+        const res = await fetch("./edit-student", {
+          method: "POST",
+          body: fd,
+          headers: { "X-Requested-With": "XMLHttpRequest" }
+        });
+
+        const data = await res.json();
+
+        if (!data.ok) {
+          Swal.showValidationMessage(data.message || "Failed to update student.");
+          return false;
+        }
+
+        return true;
+      } catch (err) {
+        console.error(err);
+        Swal.showValidationMessage("Server error.");
+        return false;
+      }
+    }
+  });
+
+  if (modal.isConfirmed) {
+    await Swal.fire("Updated!", "Student updated successfully.", "success");
+    location.reload();
+  }
+});
+</script>

--- a/css/dashboardMain.css
+++ b/css/dashboardMain.css
@@ -920,5 +920,88 @@ body {
 
   }
 
+/* --------------------------------------------------- */
+  /* QUIZZES PAGE */
+/* --------------------------------------------------- */
 
+#quizzesPage .quizCard{
+  border-radius: 16px;
+  transition: transform .12s ease, box-shadow .12s ease;
+}
+#quizzesPage .quizCard:hover{
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(0,0,0,.10) !important;
+}
+#quizzesPage .btn-primary{
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-weight: 600;
+  background-color:#524A71;
+  border-color:#524A71;
+}
+#quizzesPage .btn-outline-primary{
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-weight: 600;
+  color:#524A71;
+  border-color:#524A71;
+}
+#quizzesPage .btn-outline-primary:hover,
+#quizzesPage .btn-outline-primary.active{
+  background-color:#524A71;
+  border-color:#524A71;
+  color:#fff;
+}
+
+#quizzesPage .tab-switcher{
+  background: #f5f5f9;
+  border-radius: 14px;
+  padding: 4px;
+  display: inline-flex;
+  gap: 6px;
+}
+
+#quizzesPage .quiz-panels-wrapper{
+  position: relative;
+  overflow: hidden;
+  min-height: 320px;
+}
+
+#quizzesPage .quiz-panel{
+  width: 100%;
+  transition: opacity .28s ease, transform .28s ease;
+}
+
+#quizzesPage .quiz-panel.is-hidden{
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: translateX(30px);
+  pointer-events: none;
+}
+
+#quizzesPage .quiz-panel.is-active{
+  position: relative;
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+#quizzesPage .quiz-panel.to-left{
+  transform: translateX(-30px);
+}
+
+#quizzesPage .section-subtitle{
+  color: #6c757d;
+  margin-bottom: 0;
+}
+
+#quizzesPage .result-pill{
+  font-size: .8rem;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #eef1f7;
+  border: 1px solid #dde3ee;
+  color: #3d4b63;
+}
 

--- a/index.php
+++ b/index.php
@@ -34,6 +34,11 @@
     $route->Route(['post'], '/set-quiz-disabled', "./php/setQuizDisabled.php");
     $route->Route(['post'], '/edit-quiz', "./php/editQuiz.php");
 
+    $route->Route(['post'], '/get-student-subjects', "./php/getStudentSubjects.php");
+    $route->Route(['post'], '/add-student-subject', "./php/addStudentSubjects.php");
+    $route->Route(['post'], '/remove-student-subject', "./php/removeStudentSubjects.php");
+    $route->Route(['post'], '/edit-student', "./php/editStudent.php");
+
     $route->Route(['post'], '/update-user', "./php/updateUser.php");
 
     $route->Route(['post'], '/createAccount', "./php/createAccount.php");

--- a/index.php
+++ b/index.php
@@ -52,7 +52,7 @@
     $route->Route(['get'], '/subjects', "./contents/includes/subjectsPage.php");
     $route->Route(['get'], '/results', "./contents/includes/resultsPage.php");
     $route->Route(['get'], '/student-management', "./contents/includes/studentManagement.php");
-    $route->Route(['get'], '/test-management', "./contents/includes/testManagement.php");
+    $route->Route(['get', 'post'], '/test-management', "./contents/includes/testManagement.php");
     $route->Route(['post'], '/test-management/editor', "./contents/includes/quizManagement.php");
     $route->Route(['get'], '/lecturer-management', "./contents/includes/admLecturerManagement.php");
     $route->Route(['get'], '/subject-management', "./contents/includes/admSubjectManagement.php");

--- a/php/addStudentSubjects.php
+++ b/php/addStudentSubjects.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . "./_connect.php";
+
+$isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+          strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+
+if (!$isAjax) {
+    http_response_code(403);
+    exit;
+}
+
+header('Content-Type: application/json');
+
+$userUUID = $_POST['userUUID'] ?? '';
+$subjectUUID = $_POST['subjectUUID'] ?? '';
+
+if ($userUUID === '' || $subjectUUID === '') {
+    echo json_encode([
+        "ok" => false,
+        "message" => "Missing required fields."
+    ]);
+    exit;
+}
+
+$db = new inquizitiveDB();
+$conn = $db->connect;
+
+$db->Query("CALL AddStudentSubject(?, ?);", [$userUUID, $subjectUUID]);
+
+while (mysqli_more_results($conn) && mysqli_next_result($conn)) {
+    $extra = mysqli_store_result($conn);
+    if ($extra) mysqli_free_result($extra);
+}
+
+echo json_encode([
+    "ok" => true,
+    "message" => "Subject added successfully."
+]);

--- a/php/editStudent.php
+++ b/php/editStudent.php
@@ -1,0 +1,40 @@
+<?php
+require_once __DIR__ . "./_connect.php";
+
+$isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+          strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+
+if (!$isAjax) {
+    http_response_code(403);
+    exit;
+}
+
+header('Content-Type: application/json');
+
+$userUUID = trim($_POST['userUUID'] ?? '');
+$firstName = trim($_POST['firstName'] ?? '');
+$lastName  = trim($_POST['lastName'] ?? '');
+$email     = trim($_POST['email'] ?? '');
+
+if ($userUUID === '' || $firstName === '' || $lastName === '' || $email === '') {
+    echo json_encode([
+        "ok" => false,
+        "message" => "All fields are required."
+    ]);
+    exit;
+}
+
+$db = new inquizitiveDB();
+$conn = $db->connect;
+
+$db->Query("CALL EditStudent(?, ?, ?, ?);", [$userUUID, $firstName, $lastName, $email]);
+
+while (mysqli_more_results($conn) && mysqli_next_result($conn)) {
+    $extra = mysqli_store_result($conn);
+    if ($extra) mysqli_free_result($extra);
+}
+
+echo json_encode([
+    "ok" => true,
+    "message" => "Student updated successfully."
+]);

--- a/php/getStudentSubjects.php
+++ b/php/getStudentSubjects.php
@@ -1,0 +1,44 @@
+<?php
+require_once __DIR__ . "/_connect.php";
+
+$isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+          strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+
+if (!$isAjax) {
+    http_response_code(403);
+    exit;
+}
+
+header('Content-Type: application/json');
+
+$userUUID = trim($_POST['userUUID'] ?? '');
+
+if ($userUUID === '') {
+    echo json_encode([
+        "ok" => false,
+        "message" => "Missing userUUID."
+    ]);
+    exit;
+}
+
+$db = new inquizitiveDB();
+$conn = $db->connect;
+
+$subjects = [];
+
+if ($result = $db->Query("CALL GetStudentSubjects(?);", [$userUUID])) {
+    while ($row = mysqli_fetch_assoc($result)) {
+        $subjects[] = $row;
+    }
+    mysqli_free_result($result);
+}
+
+while (mysqli_more_results($conn) && mysqli_next_result($conn)) {
+    $extra = mysqli_store_result($conn);
+    if ($extra) mysqli_free_result($extra);
+}
+
+echo json_encode([
+    "ok" => true,
+    "subjects" => $subjects
+]);

--- a/php/removeStudentSubjects.php
+++ b/php/removeStudentSubjects.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . "./_connect.php";
+
+$isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+          strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+
+if (!$isAjax) {
+    http_response_code(403);
+    exit;
+}
+
+header('Content-Type: application/json');
+
+$userUUID = $_POST['userUUID'] ?? '';
+$subjectUUID = $_POST['subjectUUID'] ?? '';
+
+if ($userUUID === '' || $subjectUUID === '') {
+    echo json_encode([
+        "ok" => false,
+        "message" => "Missing required fields."
+    ]);
+    exit;
+}
+
+$db = new inquizitiveDB();
+$conn = $db->connect;
+
+$db->Query("CALL RemoveStudentSubject(?, ?);", [$userUUID, $subjectUUID]);
+
+while (mysqli_more_results($conn) && mysqli_next_result($conn)) {
+    $extra = mysqli_store_result($conn);
+    if ($extra) mysqli_free_result($extra);
+}
+
+echo json_encode([
+    "ok" => true,
+    "message" => "Subject removed successfully."
+]);


### PR DESCRIPTION
### Overview
(PAIR PROGRAMMING AH+EB)
This PR updates the test selection experience for students and introduces editing functionality for student accounts within the student management section.

---

### Test Selection Page
- Refactored the quizzes page into a **tabbed layout**
- Added separate sections for:
  - **Available Quizzes**
  - **Completed Quizzes**
- Implemented **animated transitions** between tabs
- Updated quiz queries to load quizzes **based on the subjects assigned to the logged-in user**
- Added **subject name and question count** to quiz cards
- Added completed quiz cards displaying:
  - quiz name
  - subject
  - score
  - completion date

---

### Student Management
Added functionality to edit student accounts directly from the management page.

Features include:
- **Edit button** for each student
- **SweetAlert modal** for editing student information
- Editable fields:
  - First Name
  - Last Name
  - Email

Subject management inside the modal:
- Display **currently enrolled subjects**
- Dropdown showing **all active subjects**
- **Add subject** button to enrol the student
- **Remove button** to unenrol subjects
- Updates handled via AJAX without leaving the page

---

### New API Endpoints
Added routes and PHP handlers for subject management:

- `get-student-subjects` → retrieves subjects assigned to a student  
- `add-student-subject` → enrols a student onto a subject  
- `remove-student-subject` → removes a subject enrolment  
- `edit-student` → updates student account details  

---

### Notes
- Quizzes are now **filtered based on the subjects assigned to the logged-in user**
- Completed quizzes are displayed in a **separate tab**
- Student subject enrolment can now be **managed directly from the edit modal**

--- 

### Planned Improvements
- Completed quizzes currently does not show, as database doesn't update when you finish a quiz. This needs to be sorted.