### PR TITLE
Initial leaderboard functionality (MT & TA)

### DIFF
--- a/contents/includes/TEMPleaderboard.php
+++ b/contents/includes/TEMPleaderboard.php
@@ -14,10 +14,10 @@ $currencyUUID = 'ec0ad14f-12c5-11f1-98eb-bc2411ac3867';
 // Get top 10 users by quantity
 $stmt = $db->Query("CALL GetTopUsersByCurrency(?)", [$currencyUUID]);
 
-$topUsers = [];
+$topIQ = [];
 while ($row = $stmt->fetch_assoc()) 
 {
-    $topUsers[] = $row;
+    $topIQ[] = $row;
 }
 ?>
 
@@ -41,12 +41,12 @@ while ($row = $stmt->fetch_assoc())
             </tr>
         </thead>
         <tbody>
-            <?php if (count($topUsers) === 0): ?>
+            <?php if (count($topIQ) === 0): ?>
                 <tr>
                     <td colspan="4" class="text-center text-muted">No users found.</td>
                 </tr>
             <?php else: ?>
-                <?php foreach ($topUsers as $index => $user): ?>
+                <?php foreach ($topIQ as $index => $user): ?>
                     <tr>
                         <td><?= $index + 1 ?></td>
                         <td><?= htmlspecialchars($user['firstName']) ?></td>

--- a/contents/includes/leaderboard.php
+++ b/contents/includes/leaderboard.php
@@ -25,6 +25,18 @@
   }
 
   $db = new InquizitiveDB();
+
+  // UUID for currency
+  $currencyUUID = 'ec0ad14f-12c5-11f1-98eb-bc2411ac3867';
+
+  // Get top 10 users by quantity
+  $stmt = $db->Query("CALL GetTopUsersByCurrency(?)", [$currencyUUID]);
+
+  $topIQ = [];
+  while ($row = $stmt->fetch_assoc()) 
+  {
+      $topIQ[] = $row;
+  }
 ?>
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
@@ -84,4 +96,35 @@
     </div>
   </div>
 </div>
+
+<div class="container py-5">
+    <h2 class="mb-4">Top 10 IQ Points</h2>
+    <table class="table table-striped table-hover">
+        <thead class="table-dark">
+            <tr>
+                <th>#</th>
+                <th>First Name</th>
+                <th>Last Name</th>
+                <th>IQ Points</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if (count($topIQ) === 0): ?>
+                <tr>
+                    <td colspan="4" class="text-center text-muted">No users found.</td>
+                </tr>
+            <?php else: ?>
+                <?php foreach ($topIQ as $index => $user): ?>
+                    <tr>
+                        <td><?= $index + 1 ?></td>
+                        <td><?= htmlspecialchars($user['firstName']) ?></td>
+                        <td><?= htmlspecialchars($user['lastName']) ?></td>
+                        <td><?= htmlspecialchars($user['score']) ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </tbody>
+    </table>
+</div>
+
 <script src="./js/leaderboard.js"></script>

--- a/contents/includes/quizResult.php
+++ b/contents/includes/quizResult.php
@@ -7,7 +7,7 @@ $score =0;
 $quizUUID = htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['quizUUID'])); // Unnecessary since we use prepared statements anyway but why not?
 $userUUID = htmlspecialchars(mysqli_real_escape_string($db->connect,$_SESSION['userUUID']));
 $array = $_POST['answers'];
- $quizInstance =  htmlspecialchars(mysqli_real_escape_string($db->connect,$_POST['quizInstance']));
+$quizInstance =  mysqli_real_escape_string($db->connect,$_POST['quizInstance']);
 // echo $quizInstance;
 
 
@@ -56,6 +56,7 @@ if ($result = $db->Query("CALL GetQuizQuestionsByID(?);",[$quizUUID])) {
     $style = "";
     for($n=0; $n < sizeof($quiz->getQuestions()); $n++)
     {
+
       if($questionUUID == $quiz->getQuestions()[$n]->getUUID())
       {
         if($answer == $quiz->getQuestions()[$n]->getAnswer())
@@ -117,9 +118,20 @@ if($score > 0){
   if(!is_null($currencyItemUUID) && !is_null($userUUID) && !is_null($userCurrency))
   {
     $db= new inquizitiveDB ();
-    $b = $db->Query("CALL SetUserInventoryItemQuantity(?,?,?);", [$userUUID,$currencyItemUUID,$moneyLeft]);
+    $b = $db->Query("CALL SetUserInventoryItemQuantity(?,?,?);", [$userUUID,$currencyItemUUID,$moneyLeft]); 
     echo '<div class="score">you gained ' . $score . " iq points</div>";
   }
+}
+
+if($score <0){$score = 0;};
+$updateQuizInstanceResult = $db->Query("CALL UpdateQuizInstanceByUUID(?,?);", [$quizInstance,$score]); 
+for($n=0; $n < sizeof($quiz->getQuestions()); $n++)
+{
+  $qAnswer = $quiz->getQuestions()[$n]->getAnswer();
+  $qUUID = $quiz->getQuestions()[$n]->getUUID();
+  $db = new inquizitiveDB();
+  $createQuizInstance =$db->Query("CALL CreateQuestionInstance(?,?,?,?)",[$quizInstance,$qUUID,$n,$qAnswer]);
+
 }
 ?>
 

--- a/index.php
+++ b/index.php
@@ -65,7 +65,7 @@
     $route->Route(['post'], '/edit-subject', "./contents/includes/editSubject.php");
     $route->Route(['post'], '/editLecturer', "./php/editLecturer.php");
     $route->Route(['post'], '/edit-lecturer', "./contents/includes/editLecturer.php");
-    $route->Route(['get'], '/getLeaderboard', "./php/getLeaderboard.php");
+    $route->Route(['post'], '/getLeaderboard', "./php/getLeaderboard.php");
 
     $route->Route(['get'], '/last-page', "./contents/includes/pageSession.php");
     $route->Route(['get'], '/logout', "./php/logout.php");

--- a/js/leaderboard.js
+++ b/js/leaderboard.js
@@ -1,9 +1,8 @@
 $(document).ready(function(){
 
+    // Allows users to select a subject to view top 5 leaderboard.
     $("#lbSubjectSelect").change(function(){
-
         const subjectUUID = $(this).val();
-
         if(subjectUUID === ""){
             $("#leaderboardResults").html(`
                 <p class="text-muted text-center">
@@ -13,45 +12,54 @@ $(document).ready(function(){
             return;
         }
 
+        // AJAX to gather data from database.
         $.ajax({
-            url: "./php/getLeaderboard",
+            url: "./getLeaderboard",
             type: "POST",
             data: {subjectUUID: subjectUUID},
             dataType: "json",
 
             success: function(res){
 
-                if(res.status === "success"){
+                if(res.status == "success"){
 
-                    let html = "";
-
+                    // Form HTML using bootstrap.
+                    let html = `<div class=" py-5">
+                                    <h2 class="mb-4">Top 5 Scores</h2>
+                                    <table class="table table-striped table-hover">
+                                        <thead class="table-dark">
+                                            <tr>
+                                                <th>#</th>
+                                                <th>First Name</th>
+                                                <th>Last Name</th>
+                                                <th>Score</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>`;
                     res.data.forEach(function(student, index)
                     {
                         let medal = "";
 
-                        if(index === 0) medal = '<span class="lb-gold">1</span>';
-                        else if(index === 1) medal = '<span class="lb-silver">2</span>';
-                        else if(index === 2) medal = '<span class="lb-bronze">3</span>';
+                        // Top 3 are colour coded.
+                        if(index == 0) medal = '<span class="lb-gold">1</span>';
+                        else if(index == 1) medal = '<span class="lb-silver">2</span>';
+                        else if(index == 2) medal = '<span class="lb-bronze">3</span>';
                         else medal = index + 1;
-
+                        
+                        // All data is sanistised using htmlspecialchar in getLeaderboard.php.
                         html += `
-                        <div class="mb-3">
+                                    <tr>
+                                        <td><strong>${medal}</strong></td>
+                                        <td>${student.firstName}</td>
+                                        <td>${student.lastName}</td>
+                                        <td><span>${student.totalScore}</span></td>
+                                    </tr>
 
-                            <div class="d-flex justify-content-between">
-                                <strong>${medal} ${student.firstName} ${student.lastName}</strong>
-                                <span>${student.score}%</span>
-                            </div>
-
-                            <div class="progress">
-                                <div class="progress-bar bg-success"
-                                     style="width:${student.score}%">
-                                </div>
-                            </div>
-
-                        </div>
                         `;
                     });
-
+                    html+= `    </tbody>
+                            </table>
+                        </div>`;
                     $("#leaderboardResults").html(html);
                 }
 
@@ -64,7 +72,8 @@ $(document).ready(function(){
                 }
             },
 
-            error:function(){
+            // If error, display message.
+            error:function( err){
                 $("#leaderboardResults").html(`
                     <p class="text-danger text-center">
                         Failed to load leaderboard.

--- a/php/getLeaderboard.php
+++ b/php/getLeaderboard.php
@@ -1,8 +1,8 @@
 <?php
 
 // Required includes.
-require_once ("./blockDirectAccess.php");
-require_once ("./_connect.php");
+require_once ("./php/blockDirectAccess.php");
+require_once ("_connect.php");
 
 // Make new database instance and set response type to JSON.
 header('Content-Type: application/json');
@@ -17,11 +17,12 @@ if(!isset($_POST['subjectUUID']))
 
 // Query database to get leaderboard data.
 $subjectUUID = $_POST['subjectUUID'];
-$stmt = $db->Query("CALL GetLeaderboard(?)", [$subjectUUID]);
+$stmt = $db->Query("CALL GetLeaderboardForSubjectUUID(?)", [$subjectUUID]);
 $data = [];
 while($row = $stmt->fetch_assoc())
 {
-    $data[] = $row;
+    $escaped = ["firstName" => htmlspecialchars($row['firstName']), "lastName" => htmlspecialchars($row['lastName']), "totalScore" => htmlspecialchars($row['totalScore'])];
+    array_push($data,$escaped);
 }
 
 // Send success status & data via JSON.


### PR DESCRIPTION
**Summary:**
- Paired programming (TA & MT) highlighted on this post.
- Currently not styled, will come in a future patch.
- "Results" on navbar changed to Leaderboards
- Students can now view leaderboards on leaderboards page.
- Students can select a subject and view top 5 user's scores within the given subject.
- Total currency leaderboard shows total IQ points leaderboard (platform-wide).
- MT: Changes added UpdateQuizInstanceByUUID & CreateQuizInstance query capabilities for future development.

**TEMPleaderboard.php:**
- Temporary page for developing purposes, currently unused and will be deleted in future patch.
- Displays top 10 total points leaderboard.

**leaderboard.php:**
- Calls top 10 users by currency.
- Displays Bootstrap leaderboard of top 10 users (by currency).
- All data escaped via htmlspecialchars to prevent XSS.

**quizResult.php (MT):**
- Now ensures score cannot be negative and updates quiz result using UpdateQuizInstanceByUUIT
- Iterates through all questions and creates question instance for each using CreateQuestionInstance

**leaderboard.js (Paired):**
- Leaderboard JS to generate Bootstrap leaderboard
- Adds ranking numbers with colour coded positions (not yet styled).
- AJAX handling (with error messages) to gather leaderboard data and dynamically insert into page.
- Displays top 5 scores for the selected subject.
- XSS prevention is handled in getLeaderboard.php

**getLeaderboard.php (Paired):** 
- Includes required connection/blockDirectAccess files.
- Handles error with no subject selected
- Calls GetLeaderboardForSubjectUUID routine to gather data.
- Includes htmlspecialchars on data to prevent XSS.

**Screenshot:**
<img width="1727" height="1262" alt="image" src="https://github.com/user-attachments/assets/e7e5b7a2-136f-4228-aca0-e9bc4cf4ec32" />
_Unstyled leaderboard page functioning_